### PR TITLE
Fixed custom key name typo in Ch2

### DIFF
--- a/kibana_scripts/ch2_getting_started.txt
+++ b/kibana_scripts/ch2_getting_started.txt
@@ -594,7 +594,7 @@ GET covid/_search
 {
   "size": 0, 
   "aggs": {
-    "total_deaths": {
+    "max_deaths": {
       "max": {
         "field": "deaths"
       }


### PR DESCRIPTION
According to the listing 2.30 in Chapter 2, MEAP v11, the user-defined custom name for the max metric aggregation should be "max_deaths", instead of "total_deaths".